### PR TITLE
Migrate from zip codes to addresses

### DIFF
--- a/components/form_shared.vue
+++ b/components/form_shared.vue
@@ -141,7 +141,7 @@
 
   import { GeoFirestore } from 'geofirestore'
   import { v4 as uuidv4 } from 'uuid';
-  import * as location from './util/location'
+  import * as location from './util/location';
 
   export default {
     props: ['dataSource', 'itemFieldLabel', 'editUuid', 'postType'],

--- a/components/form_shared.vue
+++ b/components/form_shared.vue
@@ -55,10 +55,10 @@
             ></v-text-field>
 
             <v-text-field
-                ref="zip"
-                v-model="post.zip"
-                :rules="zipRules"
-                label="ZIP / Postal Code"
+                ref="address"
+                v-model="post.address"
+                :rules="addressRules"
+                label="Address"
                 required
                 placeholder="79938"
               ></v-text-field>
@@ -141,7 +141,7 @@
 
   import { GeoFirestore } from 'geofirestore'
   import { v4 as uuidv4 } from 'uuid';
-  import * as zipcodes from 'zipcodes'
+  import * as location from './util/location'
 
   export default {
     props: ['dataSource', 'itemFieldLabel', 'editUuid', 'postType'],
@@ -158,9 +158,8 @@
         v => !!v || 'E-mail is required',
         v => /.+@.+\..+/.test(v) || 'E-mail must be valid',
       ],
-      zipRules:[
-        v => !!v || 'Zip code is required',
-        v => !!zipcodes.lookup(v) || 'Zip code must be valid',
+      addressRules:[
+        v => !!v || 'Address is required'
       ],    
       items: [],
       item_categories: [],
@@ -173,7 +172,7 @@
         item: '',
         item_category: '',
         name: '',
-        zip: '',
+        addr: '',
         quantity: 1,
         notes: '',
         status: 'New',
@@ -243,7 +242,7 @@
             this.post = {
               name: doc_data.name,
               email: doc_data.email,
-              zip: doc_data.zip,
+              address: doc_data.address,
               quantity: doc_data.quantity,
               notes: doc_data.notes,
               item: { 'name': doc_data.item },
@@ -332,24 +331,24 @@
             doc_ref = geoCollection.doc();
           }
 
-          const zipInfo = zipcodes.lookup(this.post.zip);
+          const addressInfo = location.lookup(this.post.address);
           
           const db_ref = doc_ref.set(
             {
               email: this.post.email,
-              zip: this.post.zip,
+              address: this.post.address,
               name: this.post.name,
               notes: this.post.notes,
               quantity: this.post.quantity,
               item: this.post.item.name, //for now we only store the name
-              coordinates: new this.$fireStoreObj.GeoPoint(zipInfo.latitude, zipInfo.longitude),
+              coordinates: new this.$fireStoreObj.GeoPoint(addressInfo.latitude, addressInfo.longitude),
               uuid: this.post.uuid,
               type: this.post.type,
               status: this.post.status
             }
           ).then (
             (doc_ref) => {
-              this.management_url = window.location.protocol + '//' + window.location.hostname + '/manage/' + this.postType + '/' + this.post.uuid;
+              this.management_url = window.location.protocol + '//' + window.location.host + '/manage/' + this.postType + '/' + this.post.uuid;
               this.dialog_success = true;
 
               if ( !this.editUuid ) {

--- a/components/util/location.js
+++ b/components/util/location.js
@@ -1,0 +1,11 @@
+import * as zipcodes from 'zipcodes';
+
+// TODO: Lookup any address. Right now, assumes the address is a zipcodes
+export function lookup(address) {
+  const zipInfo = zipcodes.lookup(address);
+
+  return {
+    latitude: zipInfo.latitude,
+    longitude: zipInfo.longitude
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1241,7 +1241,8 @@
     "@google-cloud/promisify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.4.tgz",
-      "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ=="
+      "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ==",
+      "optional": true
     },
     "@google-cloud/storage": {
       "version": "4.6.0",
@@ -2245,6 +2246,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "optional": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -2272,6 +2274,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
       "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "optional": true,
       "requires": {
         "debug": "4"
       },
@@ -2280,6 +2283,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2457,7 +2461,8 @@
     "arrify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "optional": true
     },
     "ascli": {
       "version": "1.0.1",
@@ -2673,7 +2678,8 @@
     "bignumber.js": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+      "optional": true
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -2911,7 +2917,8 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "optional": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4308,6 +4315,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -4584,7 +4592,8 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "optional": true
     },
     "eventemitter3": {
       "version": "4.0.0",
@@ -4729,7 +4738,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "optional": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -4863,7 +4873,8 @@
     "fast-text-encoding": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.1.tgz",
-      "integrity": "sha512-x4FEgaz3zNRtJfLFqJmHWxkMDDvXVtaznj2V9jiP8ACUJrUgist4bP9FmDL2Vew2Y9mEQI/tG4GqabaitYp9CQ=="
+      "integrity": "sha512-x4FEgaz3zNRtJfLFqJmHWxkMDDvXVtaznj2V9jiP8ACUJrUgist4bP9FmDL2Vew2Y9mEQI/tG4GqabaitYp9CQ==",
+      "optional": true
     },
     "faye-websocket": {
       "version": "0.11.3",
@@ -5205,7 +5216,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5223,11 +5235,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5240,15 +5254,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5351,7 +5368,8 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5361,6 +5379,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5373,17 +5392,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5400,6 +5422,7 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -5455,7 +5478,8 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -5480,7 +5504,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5490,6 +5515,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5558,7 +5584,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5588,6 +5615,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5605,6 +5633,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5643,11 +5672,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -5666,6 +5697,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.3.2.tgz",
       "integrity": "sha512-K/+py7UvKRDaEwEKlLiRKrFr+wjGjsMz5qH7Vs549QJS7cpSCOT/BbWL7pzqECflc46FcNPipjSfB+V1m8PAhw==",
+      "optional": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -5677,7 +5709,8 @@
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "optional": true
         }
       }
     },
@@ -5685,6 +5718,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.5.0.tgz",
       "integrity": "sha512-ZQf+DLZ5aKcRpLzYUyBS3yo3N0JSa82lNDO8rj3nMSlovLcz2riKFBsYgDzeXcv75oo5eqB2lx+B14UvPoCRnA==",
+      "optional": true,
       "requires": {
         "gaxios": "^2.1.0",
         "json-bigint": "^0.3.0"
@@ -5804,6 +5838,7 @@
       "version": "5.10.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.10.1.tgz",
       "integrity": "sha512-rOlaok5vlpV9rSiUu5EpR0vVpc+PhN62oF4RyX/6++DG1VsaulAFEMlDYBLjJDDPI6OcNOCGAKy9UVB/3NIDXg==",
+      "optional": true,
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -5859,6 +5894,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
       "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
+      "optional": true,
       "requires": {
         "node-forge": "^0.9.0"
       },
@@ -5866,7 +5902,8 @@
         "node-forge": {
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-          "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+          "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
+          "optional": true
         }
       }
     },
@@ -6308,6 +6345,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
       "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
+      "optional": true,
       "requires": {
         "gaxios": "^2.1.0",
         "google-p12-pem": "^2.0.0",
@@ -6682,6 +6720,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "optional": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -6691,6 +6730,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -6972,7 +7012,8 @@
     "is-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
-      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
+      "optional": true
     },
     "is-nan": {
       "version": "1.3.0",
@@ -7050,7 +7091,8 @@
     "is-set": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
-      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
+      "optional": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -7066,7 +7108,8 @@
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "optional": true
     },
     "is-svg": {
       "version": "3.0.0",
@@ -7087,7 +7130,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "optional": true
     },
     "is-weakmap": {
       "version": "2.0.1",
@@ -7198,6 +7242,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
       "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
+      "optional": true,
       "requires": {
         "bignumber.js": "^7.0.0"
       }
@@ -7273,6 +7318,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "optional": true,
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -7283,6 +7329,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "optional": true,
       "requires": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -10423,6 +10470,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "optional": true,
       "requires": {
         "stubs": "^3.0.0"
       }
@@ -10542,7 +10590,8 @@
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
+      "optional": true
     },
     "style-resources-loader": {
       "version": "1.3.3",
@@ -11895,7 +11944,8 @@
     "xdg-basedir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "optional": true
     },
     "xmlhttprequest": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "geofirestore": "^3.4.1",
     "nuxt": "^2.0.0",
     "nuxt-gmaps": "^1.1.9",
+    "uuid": "^7.0.2",
     "uuidv4": "^6.0.6",
     "zipcodes": "^8.0.0"
   },


### PR DESCRIPTION
Using addresses allows us to better expand the application's scope. Currently, support for non-zipcode addresses is not supported. However, we are able to easily customize this by editing `./components/util/location.js`, where all of the address lookups are performed. 